### PR TITLE
Feature: Add support for skhema filters in blueprint selectors

### DIFF
--- a/lib/blueprint.js
+++ b/lib/blueprint.js
@@ -55,15 +55,16 @@ class Blueprint extends Contract {
     this.metadata.layout = _.reduce(this.raw.layout, (accumulator, value, type) => {
       const selector = {
         cardinality: cardinality.parse(value.cardinality || value),
-        filter: value.filter
+        filter: value.filter,
+        type: value.type || type
       }
 
-      selector.cardinality.type = type
+      selector.cardinality.type = selector.type
 
       const group = selector.cardinality.finite ? 'finite' : 'infinite'
-      accumulator[group].selectors[type] = selector
-      accumulator[group].types.add(type)
-      accumulator.types.add(type)
+      accumulator[group].selectors[selector.type] = selector
+      accumulator[group].types.add(selector.type)
+      accumulator.types.add(selector.type)
 
       return accumulator
     }, {
@@ -113,7 +114,7 @@ class Blueprint extends Contract {
 
     const combinations = _.reduce(layout.finite.selectors, (accumulator, value) => {
       return accumulator.concat([
-        contract.getChildrenCombinations(value.cardinality)
+        contract.getChildrenCombinations(value)
       ])
     }, [])
 

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -18,6 +18,7 @@
 
 const _ = require('lodash')
 const combinatorics = require('js-combinatorics')
+const skhema = require('skhema')
 const hash = require('./hash')
 const TYPES = require('./types')
 const ObjectSet = require('./object-set')
@@ -830,22 +831,30 @@ class Contract {
    * > ]
    */
   getChildrenCombinations (options) {
-    const contracts = this.getChildrenByType(options.type)
+    let contracts = this.getChildrenByType(options.type)
+    const cardinality = options.cardinality || options
 
-    if (contracts.length < options.from) {
-      throw new Error(`Invalid cardinality: ${options.from} to ${options.to}. ` +
+    if (options.filter) {
+      const filterValidator = _.partial(skhema.isValid, options.filter)
+      contracts = _.filter(contracts, (con) => {
+        return filterValidator(con.raw)
+      })
+    }
+
+    if (contracts.length < cardinality.from) {
+      throw new Error(`Invalid cardinality: ${cardinality.from} to ${cardinality.to}. ` +
                       `The number of ${options.type} contracts in ` +
                       `the universe is ${contracts.length}`)
     }
 
-    if (options.from > options.to) {
-      throw new Error(`Invalid cardinality: ${options.from} to ${options.to}. ` +
+    if (cardinality.from > cardinality.to) {
+      throw new Error(`Invalid cardinality: ${cardinality.from} to ${cardinality.to}. ` +
                       'The starting point is greater than the ending point')
     }
 
-    const range = _.range(options.from, Math.min(options.to, contracts.length) + 1)
-    return _.flatMap(range, (cardinality) => {
-      return combinatorics.bigCombination(contracts, cardinality).toArray()
+    const range = _.range(cardinality.from, Math.min(cardinality.to, contracts.length) + 1)
+    return _.flatMap(range, (tcardinality) => {
+      return combinatorics.bigCombination(contracts, tcardinality).toArray()
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "handlebars-helpers": "^0.10.0",
     "js-combinatorics": "^0.5.2",
     "lodash": "^4.17.4",
-    "object-hash": "^1.1.8"
+    "object-hash": "^1.1.8",
+    "skhema": "^2.3.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/test/blueprint/constructor.spec.js
+++ b/test/blueprint/constructor.spec.js
@@ -59,7 +59,8 @@ ava.test('should parse a layout with one number selector', (test) => {
           cardinality: _.merge(cardinality.parse([ 1, 1 ]), {
             type: 'hw.device-type'
           }),
-          filter: undefined
+          filter: undefined,
+          type: 'hw.device-type'
         }
       },
       types: new Set([ 'hw.device-type' ])
@@ -85,7 +86,8 @@ ava.test('should parse a layout with one finite and one infinite selectors', (te
           cardinality: _.merge(cardinality.parse([ 2, 2 ]), {
             type: 'hw.device-type'
           }),
-          filter: undefined
+          filter: undefined,
+          type: 'hw.device-type'
         }
       },
       types: new Set([ 'hw.device-type' ])
@@ -96,7 +98,8 @@ ava.test('should parse a layout with one finite and one infinite selectors', (te
           cardinality: _.merge(cardinality.parse([ 1, Infinity ]), {
             type: 'arch.sw'
           }),
-          filter: undefined
+          filter: undefined,
+          type: 'arch.sw'
         }
       },
       types: new Set([ 'arch.sw' ])
@@ -125,7 +128,8 @@ ava.test('should support object layout selectors', (test) => {
           cardinality: _.merge(cardinality.parse([ 2, 2 ]), {
             type: 'hw.device-type'
           }),
-          filter: undefined
+          filter: undefined,
+          type: 'hw.device-type'
         }
       },
       types: new Set([ 'hw.device-type' ])
@@ -136,7 +140,8 @@ ava.test('should support object layout selectors', (test) => {
           cardinality: _.merge(cardinality.parse([ 1, Infinity ]), {
             type: 'arch.sw'
           }),
-          filter: filterFunction
+          filter: filterFunction,
+          type: 'arch.sw'
         }
       },
       types: new Set([ 'arch.sw' ])


### PR DESCRIPTION
This adds support to specify a filter in the blueprint selector.
This filter is a json schema, and only components are selected that
match this schema.

Change-type: minor
Signed-off-by: Andreas Fitzek <andreas@resin.io>