### PR TITLE
Add logical operator support in templates

### DIFF
--- a/lib/partials.js
+++ b/lib/partials.js
@@ -152,6 +152,35 @@ handlebars.registerHelper('import', (options) => {
 })
 
 /**
+* @example
+* 
+* {{#if (eq hw.device-type.data.media.installation "sdcard")}}
+*   SD card
+* {{/if}}
+* {{#if (eq hw.device-type.data.media.installation "usbkey")}}
+*  USB drive
+* {{/if}}
+*
+* {{#if (and hw.device-type.connectivity.wifi  hw.device-type.connectivity.ethernet)}}
+*   Choose network interface
+* {{/if}}
+*/
+handlebars.registerHelper({
+  eq: (v1, v2) => { return v1 === v2 },
+  ne: (v1, v2) => { return v1 !== v2 },
+  lt: (v1, v2) => { return v1 < v2 },
+  gt: (v1, v2) => { return v1 > v2 },
+  lte: (v1, v2) => { return v1 <= v2 },
+  gte: (v1, v2) => { return v1 >= v2 },
+  and (...rest) {
+    return rest.every(Boolean)
+  },
+  or (...rest) {
+    return rest.slice(0, -1).some(Boolean)
+  }
+})
+
+/**
  * @summary Build a template using a context contract
  * @function
  * @public


### PR DESCRIPTION
Handlebars supports very basic if condition checking, but it only checks for
existence of a field. There are times when we want to combine conditions in order
to generate something as part of a blueprint, without defining a completely separate
blueprint for it (like generating network config schema if a dt has a wifi chip or
a usb port to which we can connect a dongle).

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>