### PR TITLE
Add support for a "not" operator in "requires"

### DIFF
--- a/lib/contract.js
+++ b/lib/contract.js
@@ -167,7 +167,7 @@ class Contract {
       }
 
       const operationContract = Contract.createMatcher(matchers, {
-        operation: 'or'
+        operation: operand
       })
 
       this.metadata.requirements.compiled.add(operationContract, {
@@ -1353,6 +1353,24 @@ class Contract {
         // the whole contract is unsatisfied, so there's no
         // reason to keep checking the remaining requirements.
         return false
+      } else if (conjunct.raw.operation === 'not') {
+        // (3.4) Note that we should only consider disjuncts
+        // of types we are allowed to check. We can make
+        // such transformation here, so we can then consider
+        // the disjunction as fulfilled if there are no
+        // remaining disjuncts.
+        const disjuncts = _.filter(conjunct.raw.data.getAll(), (disjunct) => {
+          return shouldEvaluateType(disjunct.raw.data.type)
+        })
+
+        // (3.5) We fail the requirement if the set of negated
+        // disjuncts is not empty, and we have at least one of
+        // them in the context.
+        if (disjuncts.length > 0 && _.some(_.map(disjuncts, hasMatch))) {
+          return false
+        }
+
+        continue
       }
 
       // (4) If we reached this point, then we know we're dealing

--- a/test/contract/satisfies-child-contract.spec.js
+++ b/test/contract/satisfies-child-contract.spec.js
@@ -206,6 +206,113 @@ ava.test('should return true given no requirements in a disjunction', (test) => 
   })))
 })
 
+ava.test('should return false given a partially unfulfilled not operator', (test) => {
+  const contract = new Contract({
+    type: 'foo',
+    slug: 'bar'
+  })
+
+  contract.addChildren([
+    new Contract(CONTRACTS['sw.os'].debian.wheezy.object)
+  ])
+
+  test.false(contract.satisfiesChildContract(new Contract({
+    name: 'Node.js',
+    slug: 'nodejs',
+    type: 'sw.stack',
+    requires: [
+      {
+        not: [
+          {
+            slug: CONTRACTS['sw.os'].fedora['24'].object.slug,
+            type: 'sw.os'
+          },
+          {
+            slug: CONTRACTS['sw.os'].debian.wheezy.object.slug,
+            type: 'sw.os'
+          }
+        ]
+      }
+    ]
+  })))
+})
+
+ava.test('should return false given an unfulfilled not operator', (test) => {
+  const contract = new Contract({
+    type: 'foo',
+    slug: 'bar'
+  })
+
+  contract.addChildren([
+    new Contract(CONTRACTS['sw.os'].debian.wheezy.object)
+  ])
+
+  test.false(contract.satisfiesChildContract(new Contract({
+    name: 'Node.js',
+    slug: 'nodejs',
+    type: 'sw.stack',
+    requires: [
+      {
+        not: [
+          {
+            slug: CONTRACTS['sw.os'].debian.wheezy.object.slug,
+            type: 'sw.os'
+          }
+        ]
+      }
+    ]
+  })))
+})
+
+ava.test('should return false given a fulfilled not operator', (test) => {
+  const contract = new Contract({
+    type: 'foo',
+    slug: 'bar'
+  })
+
+  contract.addChildren([
+    new Contract(CONTRACTS['sw.os'].debian.wheezy.object)
+  ])
+
+  test.true(contract.satisfiesChildContract(new Contract({
+    name: 'Node.js',
+    slug: 'nodejs',
+    type: 'sw.stack',
+    requires: [
+      {
+        not: [
+          {
+            slug: 'foo-bar',
+            type: 'sw.os'
+          }
+        ]
+      }
+    ]
+  })))
+})
+
+ava.test('should return true given an empty not operator', (test) => {
+  const contract = new Contract({
+    type: 'foo',
+    slug: 'bar'
+  })
+
+  contract.addChildren([
+    new Contract(CONTRACTS['sw.os'].debian.wheezy.object)
+  ])
+
+  test.true(contract.satisfiesChildContract(new Contract({
+    name: 'Node.js',
+    slug: 'nodejs',
+    type: 'sw.stack',
+    requires: [
+      {
+        not: []
+      }
+    ]
+  })))
+})
+
 ava.test('should return false given two unfulfilled requirements', (test) => {
   const contract = new Contract({
     type: 'foo',


### PR DESCRIPTION
The "not" operator takes an array of contracts as an argument (as all
the other operators). 

The requirements are unfulfilled if at least one of the contracts 
declared in the "not" array exists in the context.

Change-type: minor
Fixes: https://github.com/balena-io/contrato/issues/20
Fixes: https://github.com/balena-io/balena-supervisor/issues/1388