### PR TITLE
Add support and tests for capability specification via `provides`

### DIFF
--- a/lib/blueprint.ts
+++ b/lib/blueprint.ts
@@ -50,7 +50,8 @@ export default class Blueprint extends Contract {
 			(accumulator: any, value, type) => {
 				const selector = {
 					cardinality: parse(value.cardinality || value) as any,
-					filter: value.filter,
+					// Array has its own `filter` function, which we need to ignore
+					filter: Array.isArray(value) ? undefined : value.filter,
 					type: value.type || type,
 					version: value.version,
 				};

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -648,8 +648,8 @@ export default class Contract {
 			// the list of hashes we should check against.
 			const match = matches(omit(matcher.raw.data, ['slug', 'version']));
 			const versionMatch = matcher.raw.data.version;
-			if (contract.raw.capabilities) {
-				for (const capability of contract.raw.capabilities) {
+			if (contract.raw.provides) {
+				for (const capability of contract.raw.provides) {
 					if (match(capability)) {
 						if (versionMatch) {
 							if (valid(capability.version) && validRange(versionMatch)) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,10 @@ import Blueprint from './blueprint';
 import Universe from './universe';
 import { buildTemplate } from './partials';
 
+// this is exported as is one of the return types of
+// Contract.getNotSatisfiedChildRequirements
+// TODO: remove this comment once the library has correct typings
+export { default as ObjectSet } from './object-set';
 export {
 	BlueprintLayout,
 	ContractObject,

--- a/tests/contract/satisfies-child-contract.spec.ts
+++ b/tests/contract/satisfies-child-contract.spec.ts
@@ -769,6 +769,160 @@ describe('Contract satisfiesChildContract', () => {
 		).to.be.true;
 	});
 
+	it('should return true given two fulfilled requirements from a context declaring capabilities with `provides`', () => {
+		const container = new Contract({
+			type: 'foo',
+			slug: 'bar',
+		});
+
+		const contract1 = new Contract({
+			type: 'meta.context',
+			slug: 'test',
+			provides: [
+				{
+					type: 'sw.os',
+					slug: 'debian',
+					version: 'wheezy',
+				},
+				{
+					type: 'arch.sw',
+					slug: 'amd64',
+					version: '1',
+				},
+			],
+		});
+
+		container.addChild(contract1);
+
+		expect(
+			container.satisfiesChildContract(
+				new Contract({
+					name: 'Node.js',
+					slug: 'nodejs',
+					type: 'sw.stack',
+					requires: [
+						{
+							slug: 'debian',
+							type: 'sw.os',
+						},
+						{
+							or: [
+								{
+									slug: 'amd64',
+									type: 'arch.sw',
+								},
+								{
+									slug: 'i386',
+									type: 'arch.sw',
+								},
+							],
+						},
+					],
+				}),
+			),
+		).to.be.true;
+	});
+
+	it('should return true given one fulfilled requirements from a context declaring capabilities with `provides` and one selected type', () => {
+		const container = new Contract({
+			type: 'foo',
+			slug: 'bar',
+		});
+
+		const contract1 = new Contract({
+			type: 'meta.context',
+			slug: 'test',
+			provides: [
+				{
+					type: 'sw.os',
+					slug: 'debian',
+					version: 'wheezy',
+				},
+			],
+		});
+
+		container.addChild(contract1);
+
+		expect(
+			container.satisfiesChildContract(
+				new Contract({
+					name: 'Node.js',
+					slug: 'nodejs',
+					type: 'sw.stack',
+					requires: [
+						{
+							slug: 'debian',
+							type: 'sw.os',
+						},
+						{
+							or: [
+								{
+									slug: 'amd64',
+									type: 'arch.sw',
+								},
+								{
+									slug: 'i386',
+									type: 'arch.sw',
+								},
+							],
+						},
+					],
+				}),
+				{ types: new Set(['sw.os']) },
+			),
+		).to.be.true;
+	});
+
+	it('should return false given only one fulfilled requirements from a context declaring capabilities with `provides`', () => {
+		const container = new Contract({
+			type: 'foo',
+			slug: 'bar',
+		});
+
+		const contract1 = new Contract({
+			type: 'meta.context',
+			slug: 'test',
+			provides: [
+				{
+					type: 'sw.os',
+					slug: 'debian',
+					version: 'wheezy',
+				},
+			],
+		});
+
+		container.addChild(contract1);
+
+		const child = new Contract({
+			name: 'Node.js',
+			slug: 'nodejs',
+			type: 'sw.stack',
+			requires: [
+				{
+					slug: 'debian',
+					type: 'sw.os',
+				},
+				{
+					or: [
+						{
+							slug: 'amd64',
+							type: 'arch.sw',
+						},
+						{
+							slug: 'i386',
+							type: 'arch.sw',
+						},
+					],
+				},
+			],
+		});
+
+		expect(container.satisfiesChildContract(child)).to.be.false;
+		expect(container.getNotSatisfiedChildRequirements(child)).to.have.lengthOf(
+			1,
+		);
+	});
+
 	it('should return false given one unfulfilled requirement from a context with a composite contract', () => {
 		const container = new Contract({
 			type: 'foo',


### PR DESCRIPTION
This updates the `satisfiesChildContract` and `getNotSatisfiedRequirements` functions to check for capabilities defined via `provides` on the current context. This PR is just surfacing some functionality that was already partially there but never tested.

Change-type: minor
Depends-on:  #79