### PR TITLE
Use a default Blueprint skeleton if none is provided

### DIFF
--- a/lib/blueprint.ts
+++ b/lib/blueprint.ts
@@ -9,8 +9,8 @@ import reduce from 'lodash/reduce';
 import Contract from './contract';
 import type { Cardinality } from './cardinality';
 import { parse } from './cardinality';
-import type { BlueprintLayout, BlueprintObject } from './types';
-import { BLUEPRINT } from './types';
+import type { BlueprintLayout, BlueprintObject, ContractObject } from './types';
+import { BLUEPRINT, CONTEXT } from './types';
 import {
 	cartesianProductWith,
 	flatten as flattenIterator,
@@ -54,6 +54,10 @@ export default class Blueprint extends Contract {
 	 * @param {Object} layout - the blueprint layout
 	 * @param {Object} skeleton - the blueprint skeleton
 	 *
+	 * @description Creates a new Blueprint with a given layout and skeleton
+	 *
+	 * If no skeleton is given, a default `{"type": "meta.context"}` skeleton will be used.
+	 *
 	 * @example
 	 * const blueprint = new Blueprint({
 	 *   'arch.sw': 1,
@@ -63,10 +67,10 @@ export default class Blueprint extends Contract {
 	 *   slug: '{{children.arch.sw.slug}}-{{children.hw.device-type.slug}}'
 	 * })
 	 */
-	constructor(layout: BlueprintLayout, skeleton?: any) {
+	constructor(layout: BlueprintLayout, skeleton?: ContractObject) {
 		super({
 			type: BLUEPRINT,
-			skeleton,
+			skeleton: skeleton ?? { type: CONTEXT },
 		});
 
 		const initialLayout: ParsedBlueprintLayout = {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -69,7 +69,7 @@ export {
 export function query(
 	universe: Contract,
 	layout: BlueprintLayout,
-	skeleton: object,
+	skeleton: ContractObject,
 ): IterableIterator<Contract> {
 	return new Blueprint(layout, skeleton).reproduce(universe);
 }

--- a/tests/blueprint/reproduce/reproduce.spec.ts
+++ b/tests/blueprint/reproduce/reproduce.spec.ts
@@ -90,4 +90,40 @@ describe('Blueprint reproduce', () => {
 		expect(contexts[0].hash()).to.equal(derivedContract1.hash());
 		expect(contexts[1].hash()).to.equal(derivedContract2.hash());
 	});
+
+	it('should use a `meta.context` skeleton if none is given', () => {
+		const blueprint = new Blueprint({
+			'hw.device-type': 1,
+		});
+
+		const contract1 = new Contract({
+			type: 'hw.device-type',
+			name: 'Intel Edison',
+			slug: 'intel-edison',
+		});
+
+		const contract2 = new Contract({
+			type: 'hw.device-type',
+			name: 'Intel NUC',
+			slug: 'intel-nuc',
+		});
+
+		const container = new Contract({
+			type: 'meta.universe',
+		});
+
+		container.addChildren([contract1, contract2]);
+		const contexts = Array.from(blueprint.reproduce(container));
+
+		const derivedContract1 = new Contract({ type: 'meta.context' }).addChild(
+			contract1,
+		);
+		const derivedContract2 = new Contract({ type: 'meta.context' }).addChild(
+			contract2,
+		);
+
+		expect(contexts).to.have.length(2);
+		expect(contexts[0].hash()).to.equal(derivedContract1.hash());
+		expect(contexts[1].hash()).to.equal(derivedContract2.hash());
+	});
 });

--- a/tests/contract/constructor/constructor.spec.ts
+++ b/tests/contract/constructor/constructor.spec.ts
@@ -30,4 +30,28 @@ describe('Contract constructor', () => {
 			'e3d3b7f2e5820db4b45975380a3f467bc2ff2999',
 		);
 	});
+
+	it('should should allow extra fields on round trip', () => {
+		const contract = new Contract({
+			type: 'arch.sw',
+			name: 'armv7hf',
+			slug: 'armv7hf',
+			xxx: '123',
+		});
+
+		expect(contract.raw()).to.deep.equal({
+			type: 'arch.sw',
+			name: 'armv7hf',
+			slug: 'armv7hf',
+			xxx: '123',
+		});
+
+		expect(contract.getType()).to.equal('arch.sw');
+		expect(contract.getSlug()).to.equal('armv7hf');
+		expect(contract.getVersion()).to.equal(undefined);
+		expect(contract.getCanonicalSlug()).to.equal('armv7hf');
+		expect(contract.hash()).to.equal(
+			'5fd152eb6917143accc7fea3771e92835ffe0c50',
+		);
+	});
 });


### PR DESCRIPTION
This fixes a bug that existed for a while. The Blueprint constructor allowed skeleton as an optional argument. However failing to provide a skeleton would fail when calling `reproduce` with `TypeError Cannot read properties of undefined (reading 'children').

This keeps `skeleton` as an optional property, but uses `{"type": "meta.context"}` as the default contract skeleton.

This also requires that the skeleton is of `ContractObject` type for additional compile time checks.

Change-type: minor

    