### PR TITLE
Use local types for variant expansion and improve interpolation

### DIFF
--- a/contrato-rs/README.md
+++ b/contrato-rs/README.md
@@ -128,7 +128,7 @@ let source: RawContract = serde_json::from_value(serde_json::json!({
     ]
 })).unwrap();
 
-let contracts = Contract::build(&source);
+let contracts = Contract::build(source);
 assert_eq!(contracts.len(), 2);
 assert_eq!(contracts[0].get_version(), Some("3.19".to_string()));
 assert_eq!(contracts[1].get_version(), Some("3.20".to_string()));

--- a/contrato-rs/src/children_tree.rs
+++ b/contrato-rs/src/children_tree.rs
@@ -184,11 +184,36 @@ impl<'de> Deserialize<'de> for ChildrenTree {
 /// Extracts all contracts from a [`ChildrenTree`].
 ///
 /// Recursively walks the tree and collects every [`RawContract`] found at leaf
-/// positions into a flat vector.
+/// positions into a flat vector. Use [`into_all`] instead when the tree is
+/// discarded afterwards — it moves the leaves rather than cloning them.
 pub(crate) fn get_all(tree: &ChildrenTree) -> Vec<RawContract> {
     let mut out = Vec::new();
     collect_all(tree, &mut out);
     out
+}
+
+/// Extracts all contracts from a [`ChildrenTree`], consuming it.
+///
+/// The moving counterpart of [`get_all`]: leaf contracts are taken out of the
+/// tree instead of cloned.
+pub(crate) fn into_all(tree: ChildrenTree) -> Vec<RawContract> {
+    let mut out = Vec::new();
+    collect_into(tree, &mut out);
+    out
+}
+
+/// Recursive helper for [`into_all`], mirroring [`collect_all`] over an owned
+/// tree.
+fn collect_into(tree: ChildrenTree, out: &mut Vec<RawContract>) {
+    match tree {
+        ChildrenTree::Branch(map) => {
+            for child in map.into_values() {
+                collect_into(child, out);
+            }
+        }
+        ChildrenTree::Single(contract) => out.push(*contract),
+        ChildrenTree::Multiple(contracts) => out.extend(contracts),
+    }
 }
 
 /// Recursive helper that accumulates contracts into a single `Vec`, avoiding

--- a/contrato-rs/src/children_tree.rs
+++ b/contrato-rs/src/children_tree.rs
@@ -181,29 +181,18 @@ impl<'de> Deserialize<'de> for ChildrenTree {
     }
 }
 
-/// Extracts all contracts from a [`ChildrenTree`].
-///
-/// Recursively walks the tree and collects every [`RawContract`] found at leaf
-/// positions into a flat vector. Use [`into_all`] instead when the tree is
-/// discarded afterwards — it moves the leaves rather than cloning them.
-pub(crate) fn get_all(tree: &ChildrenTree) -> Vec<RawContract> {
-    let mut out = Vec::new();
-    collect_all(tree, &mut out);
-    out
-}
-
 /// Extracts all contracts from a [`ChildrenTree`], consuming it.
 ///
-/// The moving counterpart of [`get_all`]: leaf contracts are taken out of the
-/// tree instead of cloned.
+/// Recursively walks the tree and moves every [`RawContract`] found at leaf
+/// positions into a flat vector.
 pub(crate) fn into_all(tree: ChildrenTree) -> Vec<RawContract> {
     let mut out = Vec::new();
     collect_into(tree, &mut out);
     out
 }
 
-/// Recursive helper for [`into_all`], mirroring [`collect_all`] over an owned
-/// tree.
+/// Recursive helper that accumulates contracts into a single `Vec`, avoiding
+/// intermediate allocations from `flat_map` + `collect` at each branch level.
 fn collect_into(tree: ChildrenTree, out: &mut Vec<RawContract>) {
     match tree {
         ChildrenTree::Branch(map) => {
@@ -213,20 +202,6 @@ fn collect_into(tree: ChildrenTree, out: &mut Vec<RawContract>) {
         }
         ChildrenTree::Single(contract) => out.push(*contract),
         ChildrenTree::Multiple(contracts) => out.extend(contracts),
-    }
-}
-
-/// Recursive helper that accumulates contracts into a single `Vec`, avoiding
-/// intermediate allocations from `flat_map` + `collect` at each branch level.
-fn collect_all(tree: &ChildrenTree, out: &mut Vec<RawContract>) {
-    match tree {
-        ChildrenTree::Branch(map) => {
-            for child in map.values() {
-                collect_all(child, out);
-            }
-        }
-        ChildrenTree::Single(contract) => out.push(contract.as_ref().clone()),
-        ChildrenTree::Multiple(contracts) => out.extend_from_slice(contracts),
     }
 }
 
@@ -546,38 +521,38 @@ mod tests {
     fn deserialize_empty_array() {
         let tree: ChildrenTree = serde_json::from_value(json!([])).unwrap();
         assert_eq!(tree, ChildrenTree::Multiple(vec![]));
-        assert!(get_all(&tree).is_empty());
+        assert!(into_all(tree).is_empty());
     }
 
     // -----------------------------------------------------------------------
-    // get_all tests
+    // into_all tests
     // -----------------------------------------------------------------------
 
     #[test]
-    fn get_all_empty_tree() {
+    fn into_all_empty_tree() {
         let tree = ChildrenTree::Branch(BTreeMap::new());
-        assert!(get_all(&tree).is_empty());
+        assert!(into_all(tree).is_empty());
     }
 
     #[test]
-    fn get_all_root_is_single() {
+    fn into_all_root_is_single() {
         let c = raw_contract("sw.os", "debian", Some("wheezy"));
         let tree = ChildrenTree::Single(Box::new(c.clone()));
-        let result = get_all(&tree);
+        let result = into_all(tree);
         assert_eq!(result, vec![c]);
     }
 
     #[test]
-    fn get_all_root_is_multiple() {
+    fn into_all_root_is_multiple() {
         let c1 = raw_contract("sw.os", "debian", Some("wheezy"));
         let c2 = raw_contract("sw.os", "debian", Some("jessie"));
         let tree = ChildrenTree::Multiple(vec![c1.clone(), c2.clone()]);
-        let result = get_all(&tree);
+        let result = into_all(tree);
         assert_eq!(result, vec![c1, c2]);
     }
 
     #[test]
-    fn get_all_single_contract() {
+    fn into_all_single_contract() {
         let tree: ChildrenTree = serde_json::from_value(json!({
             "sw": {
                 "os": {
@@ -589,13 +564,13 @@ mod tests {
         }))
         .unwrap();
 
-        let result = get_all(&tree);
+        let result = into_all(tree);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].body.slug.as_ref().unwrap().as_str(), "debian");
     }
 
     #[test]
-    fn get_all_multiple_types() {
+    fn into_all_multiple_types() {
         let tree: ChildrenTree = serde_json::from_value(json!({
             "sw": {
                 "os": { "type": "sw.os", "slug": "debian", "version": "wheezy" },
@@ -604,7 +579,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = get_all(&tree);
+        let result = into_all(tree);
         assert_eq!(result.len(), 2);
         let slugs: HashSet<&str> = result
             .iter()
@@ -615,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn get_all_nested_by_slug() {
+    fn into_all_nested_by_slug() {
         let tree: ChildrenTree = serde_json::from_value(json!({
             "sw": {
                 "os": {
@@ -626,12 +601,12 @@ mod tests {
         }))
         .unwrap();
 
-        let result = get_all(&tree);
+        let result = into_all(tree);
         assert_eq!(result.len(), 2);
     }
 
     #[test]
-    fn get_all_array_of_same_slug() {
+    fn into_all_array_of_same_slug() {
         let tree: ChildrenTree = serde_json::from_value(json!({
             "sw": {
                 "os": {
@@ -644,7 +619,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = get_all(&tree);
+        let result = into_all(tree);
         assert_eq!(result.len(), 2);
         let versions: HashSet<String> = result
             .iter()
@@ -694,13 +669,14 @@ mod tests {
         };
 
         let result = build(&index).unwrap();
-        let extracted = get_all(&result);
-        assert_eq!(extracted.len(), 1);
-        assert_eq!(extracted[0], c1);
 
         // Verify full tree shape: sw -> os -> Single(contract)
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json.pointer("/sw/os/slug").unwrap(), "debian");
+
+        let extracted = into_all(result);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0], c1);
     }
 
     #[test]
@@ -736,7 +712,7 @@ mod tests {
         assert_eq!(json.pointer("/sw/os/slug").unwrap(), "debian");
         assert_eq!(json.pointer("/sw/blob/slug").unwrap(), "nodejs");
 
-        let extracted = get_all(&result);
+        let extracted = into_all(result);
         assert_eq!(extracted.len(), 2);
         assert!(extracted.contains(&c1));
         assert!(extracted.contains(&c2));
@@ -755,7 +731,7 @@ mod tests {
             contracts: HashMap::new(),
         };
         let result = build(&index).unwrap();
-        assert!(get_all(&result).is_empty());
+        assert!(into_all(result).is_empty());
     }
 
     #[test]
@@ -778,7 +754,7 @@ mod tests {
             contracts: HashMap::new(),
         };
         let result = build(&index).unwrap();
-        assert!(get_all(&result).is_empty());
+        assert!(into_all(result).is_empty());
     }
 
     #[test]
@@ -803,7 +779,7 @@ mod tests {
             ]),
         };
         let result = build(&index).unwrap();
-        assert!(get_all(&result).is_empty());
+        assert!(into_all(result).is_empty());
     }
 
     #[test]
@@ -830,15 +806,16 @@ mod tests {
         };
 
         let result = build(&index).unwrap();
-        let extracted = get_all(&result);
-        assert_eq!(extracted.len(), 2);
-        assert!(extracted.contains(&c1));
-        assert!(extracted.contains(&c2));
 
         // Verify tree shape: sw -> os -> {debian, fedora}
         let json = serde_json::to_value(&result).unwrap();
         assert!(json.pointer("/sw/os/debian").is_some());
         assert!(json.pointer("/sw/os/fedora").is_some());
+
+        let extracted = into_all(result);
+        assert_eq!(extracted.len(), 2);
+        assert!(extracted.contains(&c1));
+        assert!(extracted.contains(&c2));
     }
 
     #[test]
@@ -872,7 +849,7 @@ mod tests {
         assert!(arr.is_array());
         assert_eq!(arr.as_array().unwrap().len(), 2);
 
-        let extracted = get_all(&result);
+        let extracted = into_all(result);
         assert_eq!(extracted.len(), 2);
         assert!(extracted.contains(&c1));
         assert!(extracted.contains(&c2));
@@ -1060,11 +1037,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Round-trip: build → get_all
+    // Round-trip: build → into_all
     // -----------------------------------------------------------------------
 
     #[test]
-    fn round_trip_build_then_get_all() {
+    fn round_trip_build_then_into_all() {
         let c1 = raw_contract("sw.os", "debian", Some("wheezy"));
         let c2 = raw_contract("sw.blob", "nodejs", Some("4.8.0"));
         let h1 = "hash1".to_string();
@@ -1090,7 +1067,7 @@ mod tests {
         };
 
         let tree = build(&index).unwrap();
-        let extracted = get_all(&tree);
+        let extracted = into_all(tree);
         assert_eq!(extracted.len(), 2);
         assert!(extracted.contains(&c1));
         assert!(extracted.contains(&c2));
@@ -1120,7 +1097,7 @@ mod tests {
         };
 
         let tree = build(&index).unwrap();
-        let extracted = get_all(&tree);
+        let extracted = into_all(tree);
         assert_eq!(extracted.len(), 2);
         assert!(extracted.contains(&c1));
         assert!(extracted.contains(&c2));

--- a/contrato-rs/src/contract.rs
+++ b/contrato-rs/src/contract.rs
@@ -374,12 +374,10 @@ impl Contract {
     ///    `aliases` cleared.
     ///
     /// The alias contracts come before the base contract in the output.
-    pub fn build(source: &RawContract) -> Vec<Contract> {
+    pub fn build(source: RawContract) -> Vec<Contract> {
         let mut result = Vec::new();
-        for variant in variants::build(source) {
-            let aliases: Vec<Slug> = variant.body.aliases.clone();
-            let mut base = variant;
-            base.body.aliases.clear();
+        for mut base in variants::build(source) {
+            let aliases: Vec<Slug> = std::mem::take(&mut base.body.aliases);
 
             for alias in aliases {
                 let mut alias_contract = base.clone();
@@ -1800,7 +1798,7 @@ mod tests {
 
     #[test]
     fn build_single_contract_no_variants() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "name": "Debian Wheezy",
             "slug": "debian",
             "version": "wheezy",
@@ -1813,7 +1811,7 @@ mod tests {
 
     #[test]
     fn build_expands_templates() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "name": "Debian {{this.data.codename}}",
             "slug": "debian",
             "version": "wheezy",
@@ -1833,7 +1831,7 @@ mod tests {
 
     #[test]
     fn build_supports_slug_and_type_templates() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "name": "Debian Wheezy",
             "slug": "{{this.data.slug}}",
             "version": "wheezy",
@@ -1847,7 +1845,7 @@ mod tests {
 
     #[test]
     fn build_expands_variants() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "slug": "debian",
             "type": "sw.os",
             "variants": [
@@ -1870,7 +1868,7 @@ mod tests {
 
     #[test]
     fn build_keeps_children_declared_on_base_and_variant() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "slug": "debian",
             "type": "sw.os",
             "children": [
@@ -1895,8 +1893,36 @@ mod tests {
     }
 
     #[test]
+    fn build_keeps_same_type_children_declared_on_base_and_variant() {
+        // Two capabilities of the same type at the same tree path. Merging the
+        // children trees structurally collapses them into one hybrid contract;
+        // both must survive the re-index instead.
+        let contracts = Contract::build(raw(json!({
+            "slug": "myapp",
+            "type": "sw.application",
+            "children": {
+                "sw": { "os": { "type": "sw.os", "slug": "debian" } }
+            },
+            "variants": [
+                {
+                    "children": {
+                        "sw": { "os": { "type": "sw.os", "slug": "fedora" } }
+                    }
+                }
+            ]
+        })));
+        assert_eq!(contracts.len(), 1);
+
+        let debian = matcher("sw.os", Some("debian"), None);
+        assert_eq!(contracts[0].find_children(&debian).len(), 1);
+
+        let fedora = matcher("sw.os", Some("fedora"), None);
+        assert_eq!(contracts[0].find_children(&fedora).len(), 1);
+    }
+
+    #[test]
     fn build_variants_with_templates() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "name": "debian {{this.version}}",
             "slug": "debian",
             "type": "sw.os",
@@ -1912,7 +1938,7 @@ mod tests {
 
     #[test]
     fn build_expands_aliases() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "slug": "debian",
             "type": "sw.os",
             "version": "jessie",
@@ -1930,7 +1956,7 @@ mod tests {
 
     #[test]
     fn build_variants_and_aliases() {
-        let contracts = Contract::build(&raw(json!({
+        let contracts = Contract::build(raw(json!({
             "name": "debian {{this.version}}",
             "slug": "debian",
             "type": "sw.os",

--- a/contrato-rs/src/contract.rs
+++ b/contrato-rs/src/contract.rs
@@ -110,19 +110,21 @@ impl Contract {
             requirements: RequirementsIndex::default(),
         };
 
-        let child_sources: Vec<RawContract> = this
-            .raw
-            .body
-            .children
-            .as_ref()
-            .map(children_tree::get_all)
-            .unwrap_or_default();
+        // Templates are compiled before the children are extracted so
+        // that `{{this.children.*}}` references still resolve against
+        // the incoming tree.
+        this.compile_templates();
 
-        for source in child_sources {
-            let _ = this.children.insert(Contract::new(source));
+        // The tree is moved out instead of cloned: `rebuild` below
+        // regenerates `raw.children` from the index, so the incoming
+        // tree is discarded either way.
+        if let Some(children) = this.raw.body.children.take() {
+            for source in children_tree::into_all(children) {
+                let _ = this.children.insert(Contract::new(source));
+            }
         }
 
-        this.interpolate();
+        this.rebuild();
         this
     }
 
@@ -143,6 +145,13 @@ impl Contract {
     /// fields during its own construction. [`Self::rebuild`] is called
     /// at the end, which invalidates the hash cell.
     pub fn interpolate(&mut self) {
+        self.compile_templates();
+        self.rebuild();
+    }
+
+    /// Compiles `{{this.*}}` templates in `raw` in place, leaving derived
+    /// state untouched.
+    fn compile_templates(&mut self) {
         let mut blacklist = HashSet::new();
         blacklist.insert("children".to_string());
 
@@ -151,8 +160,6 @@ impl Contract {
         let compiled = template::compile_contract(&raw_value, &blacklist, None);
         self.raw = serde_json::from_value(compiled)
             .expect("compiled contract must deserialize into RawContract");
-
-        self.rebuild();
     }
 
     /// Rebuilds derived state from the current children index and
@@ -1487,12 +1494,34 @@ mod tests {
 
         // Children are interpolated against their own fields; the child has
         // no `version`, so the template stays unresolved.
-        let tree = c.raw.body.children.as_ref().unwrap();
-        let extracted = children_tree::get_all(tree);
+        let tree = c.raw.body.children.expect("children present");
+        let extracted = children_tree::into_all(tree);
         assert_eq!(extracted.len(), 1);
         assert_eq!(
             extracted[0].body.slug.as_ref().unwrap().as_str(),
             "{{this.version}}-child"
+        );
+    }
+
+    #[test]
+    fn interpolate_resolves_this_children_references() {
+        // `Contract::new` moves the children tree out of `raw` to build its
+        // index; this locks in that the move happens *after* template
+        // compilation, so the parent can still reference its children.
+        let c = contract(json!({
+            "type": "sw.os",
+            "slug": "board-{{this.children.hw.device-type.slug}}",
+            "children": {
+                "hw": {
+                    "device-type": { "type": "hw.device-type", "slug": "raspberrypi4" }
+                }
+            }
+        }));
+
+        assert_eq!(
+            c.raw.body.slug.as_ref().unwrap().as_str(),
+            "board-raspberrypi4",
+            "parent template must resolve against the incoming children tree"
         );
     }
 

--- a/contrato-rs/src/variants.rs
+++ b/contrato-rs/src/variants.rs
@@ -3,65 +3,179 @@
 //! Contract variants are syntax sugar that allows expressing multiple different
 //! contracts sharing many properties as a single object, to avoid repetition.
 //! A contract with a `variants` array is expanded into N contracts, one per
-//! variant, where each variant is deep-merged with the base contract.
+//! variant, where each variant is merged with the base contract.
+
+use std::collections::HashMap;
 
 use serde_json::Value;
 
-use crate::types::RawContract;
+use crate::children_tree::{self, ChildrenTree};
+use crate::types::{Asset, PartialContract, RawContract};
 
 /// Expands a contract's variants into a flat list of contracts.
 ///
 /// If the contract has no `variants` (or an empty array), returns a
 /// single-element vec containing the contract with `variants` removed.
-/// Otherwise, each variant is recursively expanded and deep-merged with
-/// the base contract. During merge, arrays are concatenated (base first,
-/// then variant) and objects are recursively merged.
-///
-/// # Panics
-///
-/// Panics if the contract cannot be serialized to JSON or if any expanded
-/// variant cannot be deserialized back into a [`ContractObject`].
-pub(crate) fn build(contract: &RawContract) -> Vec<RawContract> {
-    let value = serde_json::to_value(contract).expect("ContractObject must serialize to JSON");
-    build_value(&value)
+/// Otherwise, each variant is recursively expanded and merged with the base
+/// contract. See [`merge_partial`] for the per-field merge rules.
+pub(crate) fn build(contract: RawContract) -> Vec<RawContract> {
+    let RawContract {
+        kind,
+        canonical_slug,
+        body,
+        extra,
+    } = contract;
+
+    let mut bodies = expand_partial(body);
+    let last = bodies.pop();
+
+    let mut result: Vec<RawContract> = bodies
         .into_iter()
-        .map(|v| serde_json::from_value(v).expect("expanded variant must deserialize"))
-        .collect()
+        .map(|body| RawContract {
+            kind: kind.clone(),
+            canonical_slug: canonical_slug.clone(),
+            body,
+            extra: extra.clone(),
+        })
+        .collect();
+
+    if let Some(body) = last {
+        result.push(RawContract {
+            kind,
+            canonical_slug,
+            body,
+            extra,
+        });
+    }
+    result
 }
 
-/// Recursive variant expansion operating on raw JSON values.
+/// Recursive variant expansion over [`PartialContract`].
 ///
-/// Extracts the `variants` array from the object, removes it from the base,
-/// then for each variant recursively expands it and deep-merges each result
-/// with the base.
-fn build_value(contract: &Value) -> Vec<Value> {
-    // Non-object values pass through unchanged. This handles the recursive case
-    // where a malformed variant entry is not an object.
-    let obj = match contract.as_object() {
-        Some(o) => o,
-        None => return vec![contract.clone()],
-    };
+/// A contract without variants expands to itself. Otherwise each variant is
+/// recursively expanded and every expansion is merged onto the contract, which
+/// acts as the base
+fn expand_partial(mut partial: PartialContract) -> Vec<PartialContract> {
+    if partial.variants.is_empty() {
+        return vec![partial];
+    }
 
-    let mut base = obj.clone();
-    let variants = base.remove("variants");
-    let base = Value::Object(base);
+    let variants = std::mem::take(&mut partial.variants);
+    let base = partial;
 
-    let variants = match variants.as_ref().and_then(Value::as_array) {
-        Some(v) if !v.is_empty() => v,
-        _ => return vec![base],
-    };
+    let mut templates: Vec<PartialContract> =
+        variants.into_iter().flat_map(expand_partial).collect();
+    let last = templates.pop();
 
-    variants
-        .iter()
-        .flat_map(|variation| {
-            build_value(variation)
-                .into_iter()
-                .map(|template| deep_merge(&base, &template))
-        })
-        .collect()
+    let mut expanded: Vec<PartialContract> = templates
+        .into_iter()
+        .map(|template| merge_partial(base.clone(), template))
+        .collect();
+
+    if let Some(template) = last {
+        expanded.push(merge_partial(base, template));
+    }
+    expanded
+}
+
+/// Merges a variant (`overlay`) onto a base contract body.
+///
+/// - `slug`, `version`, `name`, `description`: the overlay wins when set.
+/// - `aliases`, `requires`: concatenated, base first.
+/// - `data`: recursively [`deep_merge`]d when both sides are set, otherwise the
+///   overlay wins when set.
+/// - `assets`: merged key-wise; colliding keys are merged field-wise by
+///   [`merge_asset`].
+/// - `children`: flattened and concatenated by [`merge_children`].
+/// - `variants`: dropped — a merged contract is by definition already expanded.
+fn merge_partial(base: PartialContract, overlay: PartialContract) -> PartialContract {
+    PartialContract {
+        slug: overlay.slug.or(base.slug),
+        version: overlay.version.or(base.version),
+        name: overlay.name.or(base.name),
+        description: overlay.description.or(base.description),
+        aliases: concat(base.aliases, overlay.aliases),
+        data: match (base.data, overlay.data) {
+            (Some(b), Some(o)) => Some(deep_merge(&b, &o)),
+            (b, o) => o.or(b),
+        },
+        assets: merge_assets(base.assets, overlay.assets),
+        requires: concat(base.requires, overlay.requires),
+        variants: Vec::new(),
+        children: merge_children(base.children, overlay.children),
+    }
+}
+
+/// Appends the overlay's elements to the base's, reusing the base's allocation.
+fn concat<T>(mut base: Vec<T>, overlay: Vec<T>) -> Vec<T> {
+    base.extend(overlay);
+    base
+}
+
+/// Merges two asset maps key-wise, merging colliding entries field-wise.
+fn merge_assets(
+    mut base: HashMap<String, Asset>,
+    overlay: HashMap<String, Asset>,
+) -> HashMap<String, Asset> {
+    for (key, asset) in overlay {
+        let merged = match base.remove(&key) {
+            Some(existing) => merge_asset(existing, asset),
+            None => asset,
+        };
+        base.insert(key, merged);
+    }
+    base
+}
+
+/// Merges two assets field-wise.
+///
+/// `url` is required on both sides, so the overlay's always wins. The optional
+/// fields fall back to the base when the overlay leaves them unset, and the
+/// untyped `extra` fields are deep-merged like `data`.
+fn merge_asset(base: Asset, overlay: Asset) -> Asset {
+    let mut extra = base.extra;
+    for (key, val) in overlay.extra {
+        let merged = match extra.get(&key) {
+            Some(existing) => deep_merge(existing, &val),
+            None => val,
+        };
+        extra.insert(key, merged);
+    }
+
+    Asset {
+        url: overlay.url,
+        name: overlay.name.or(base.name),
+        checksum: overlay.checksum.or(base.checksum),
+        checksum_type: overlay.checksum_type.or(base.checksum_type),
+        extra,
+    }
+}
+
+/// Merges two children trees by flattening both sides and concatenating them,
+/// base children first.
+///
+/// Children declare the capabilities a contract provides to its context, so the
+/// merge must be a union: a structural tree merge would collapse two different
+/// capabilities sharing a type path into a single hybrid contract.
+fn merge_children(
+    base: Option<ChildrenTree>,
+    overlay: Option<ChildrenTree>,
+) -> Option<ChildrenTree> {
+    match (base, overlay) {
+        (None, None) => None,
+        (base, overlay) => Some(ChildrenTree::Multiple(
+            base.into_iter()
+                .chain(overlay)
+                .flat_map(children_tree::into_all)
+                .collect(),
+        )),
+    }
 }
 
 /// Deep-merges two JSON values with array concatenation semantics.
+///
+/// Only used for the untyped `data` field; every other field has a typed rule
+/// in [`merge_partial`].
 ///
 /// - **Objects**: keys from `overlay` are merged into `base` recursively.
 ///   Keys present only in `base` are preserved; keys present only in
@@ -104,7 +218,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -128,7 +242,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -162,7 +276,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 2);
 
         let jsons: Vec<Value> = result
@@ -220,7 +334,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 3);
 
         let jsons: Vec<Value> = result
@@ -279,7 +393,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 2);
 
         let jsons: Vec<Value> = result
@@ -327,7 +441,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -358,7 +472,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -389,7 +503,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -429,7 +543,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -444,6 +558,42 @@ mod tests {
                         "debug": true,
                         "retry": { "enabled": true, "count": 5, "backoff": "exponential" }
                     }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn build_preserves_unknown_asset_fields() {
+        // Contracts attach their own metadata to assets and reference it from
+        // templated fields, so unknown keys must survive expansion.
+        let contract: RawContract = serde_json::from_value(json!({
+            "slug": "fedora",
+            "type": "sw.os",
+            "assets": {
+                "test": {
+                    "main": "test-os",
+                    "commit": "a95300e",
+                    "url": "https://example.com/{{this.assets.test.commit}}/script.sh"
+                }
+            },
+            "variants": [
+                { "assets": { "test": { "commit": "b12f4c1", "url": "https://example.com/{{this.assets.test.commit}}/script.sh" } } }
+            ]
+        }))
+        .unwrap();
+
+        let result = build(contract);
+        assert_eq!(result.len(), 1);
+
+        let json = serde_json::to_value(&result[0]).unwrap();
+        assert_eq!(
+            json["assets"],
+            json!({
+                "test": {
+                    "main": "test-os",
+                    "commit": "b12f4c1",
+                    "url": "https://example.com/{{this.assets.test.commit}}/script.sh"
                 }
             })
         );
@@ -529,7 +679,7 @@ mod tests {
             extra: Map::new(),
         };
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 2);
 
         let jsons: Vec<Value> = result
@@ -577,7 +727,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = build(&contract);
+        let result = build(contract);
         assert_eq!(result.len(), 1);
 
         let json = serde_json::to_value(&result[0]).unwrap();
@@ -585,5 +735,180 @@ mod tests {
         assert_eq!(json["type"], "sw.app");
         assert_eq!(json["name"], "My Service");
         assert_eq!(json["slug"], "myapp");
+    }
+
+    /// Expands a contract expected to yield exactly one result and returns its
+    /// children as `type/slug` strings, in order.
+    ///
+    /// The assertions are on the flattened set of children, not on tree shape:
+    /// the shape emitted by the merge is an intermediate that `Contract::new`
+    /// regenerates from its child index.
+    fn expand_child_ids(contract: Value) -> Vec<String> {
+        let contract: RawContract = serde_json::from_value(contract).unwrap();
+        let result = build(contract);
+        assert_eq!(result.len(), 1);
+
+        let children = result[0].body.children.as_ref().expect("children present");
+        children_tree::get_all(children)
+            .iter()
+            .map(|c| format!("{}/{}", c.kind, c.body.slug.as_ref().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn build_concatenates_children_lists() {
+        assert_eq!(
+            expand_child_ids(json!({
+                "slug": "debian",
+                "type": "sw.os",
+                "children": [{ "type": "sw.feature", "slug": "secureboot" }],
+                "variants": [
+                    { "children": [{ "type": "arch.sw", "slug": "amd64" }] }
+                ]
+            })),
+            ["sw.feature/secureboot", "arch.sw/amd64"]
+        );
+    }
+
+    #[test]
+    fn build_merges_disjoint_children_trees() {
+        assert_eq!(
+            expand_child_ids(json!({
+                "slug": "debian",
+                "type": "sw.os",
+                "children": {
+                    "sw": { "feature": { "type": "sw.feature", "slug": "secureboot" } }
+                },
+                "variants": [
+                    {
+                        "children": {
+                            "arch": { "sw": { "type": "arch.sw", "slug": "amd64" } }
+                        }
+                    }
+                ]
+            })),
+            ["sw.feature/secureboot", "arch.sw/amd64"]
+        );
+    }
+
+    #[test]
+    fn build_keeps_children_of_same_type_with_different_slugs() {
+        // Regression guard: a structural tree merge collapses these two into a
+        // single hybrid contract, destroying the base's capability.
+        assert_eq!(
+            expand_child_ids(json!({
+                "slug": "myapp",
+                "type": "sw.application",
+                "children": {
+                    "sw": { "os": { "type": "sw.os", "slug": "debian", "version": "wheezy" } }
+                },
+                "variants": [
+                    {
+                        "children": {
+                            "sw": { "os": { "type": "sw.os", "slug": "fedora", "version": "38" } }
+                        }
+                    }
+                ]
+            })),
+            ["sw.os/debian", "sw.os/fedora"]
+        );
+    }
+
+    #[test]
+    fn build_merges_children_list_with_tree() {
+        assert_eq!(
+            expand_child_ids(json!({
+                "slug": "myapp",
+                "type": "sw.application",
+                "children": [
+                    { "type": "sw.feature", "slug": "secureboot" },
+                    { "type": "sw.feature", "slug": "tpm" }
+                ],
+                "variants": [
+                    {
+                        "children": {
+                            "arch": { "sw": { "type": "arch.sw", "slug": "amd64" } }
+                        }
+                    }
+                ]
+            })),
+            ["sw.feature/secureboot", "sw.feature/tpm", "arch.sw/amd64"]
+        );
+    }
+
+    #[test]
+    fn build_keeps_base_only_children() {
+        assert_eq!(
+            expand_child_ids(json!({
+                "slug": "debian",
+                "type": "sw.os",
+                "children": [{ "type": "sw.feature", "slug": "secureboot" }],
+                "variants": [{ "version": "wheezy" }]
+            })),
+            ["sw.feature/secureboot"]
+        );
+    }
+
+    #[test]
+    fn build_keeps_variant_only_children() {
+        assert_eq!(
+            expand_child_ids(json!({
+                "slug": "debian",
+                "type": "sw.os",
+                "variants": [
+                    { "children": [{ "type": "arch.sw", "slug": "amd64" }] }
+                ]
+            })),
+            ["arch.sw/amd64"]
+        );
+    }
+
+    #[test]
+    fn build_merges_colliding_assets_field_wise() {
+        let contract: RawContract = serde_json::from_value(json!({
+            "slug": "firmware",
+            "type": "sw.blob",
+            "assets": {
+                "binary": {
+                    "url": "https://example.com/base.bin",
+                    "name": "Base binary",
+                    "checksum": "abc123",
+                    "checksumType": "sha256"
+                },
+                "docs": { "url": "https://example.com/docs.pdf" }
+            },
+            "variants": [
+                {
+                    "assets": {
+                        "binary": {
+                            "url": "https://example.com/variant.bin",
+                            "checksum": "def456"
+                        },
+                        "extra": { "url": "https://example.com/extra.bin" }
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+
+        let result = build(contract);
+        assert_eq!(result.len(), 1);
+
+        let json = serde_json::to_value(&result[0]).unwrap();
+        assert_eq!(
+            json["assets"],
+            json!({
+                "binary": {
+                    // `url` is required, so the overlay's always wins; the
+                    // optional fields the overlay leaves unset fall back.
+                    "url": "https://example.com/variant.bin",
+                    "name": "Base binary",
+                    "checksum": "def456",
+                    "checksumType": "sha256"
+                },
+                "docs": { "url": "https://example.com/docs.pdf" },
+                "extra": { "url": "https://example.com/extra.bin" }
+            })
+        );
     }
 }

--- a/contrato-rs/src/variants.rs
+++ b/contrato-rs/src/variants.rs
@@ -748,8 +748,14 @@ mod tests {
         let result = build(contract);
         assert_eq!(result.len(), 1);
 
-        let children = result[0].body.children.as_ref().expect("children present");
-        children_tree::get_all(children)
+        let children = result
+            .into_iter()
+            .next()
+            .unwrap()
+            .body
+            .children
+            .expect("children present");
+        children_tree::into_all(children)
             .iter()
             .map(|c| format!("{}/{}", c.kind, c.body.slug.as_ref().unwrap()))
             .collect()

--- a/contrato-rs/tests/readme_examples.rs
+++ b/contrato-rs/tests/readme_examples.rs
@@ -91,7 +91,7 @@ fn readme_variants() {
         ]
     }))
     .unwrap();
-    let contracts = contrato::Contract::build(&source);
+    let contracts = contrato::Contract::build(source);
     assert_eq!(contracts.len(), 2);
     assert_eq!(contracts[0].get_version(), Some("3.19".to_string()));
     assert_eq!(contracts[1].get_version(), Some("3.20".to_string()));

--- a/contrato-wasm/src/lib.rs
+++ b/contrato-wasm/src/lib.rs
@@ -353,7 +353,7 @@ impl WasmContract {
     #[wasm_bindgen(js_name = build)]
     pub fn build(source: JsValue) -> Result<Array, JsValue> {
         let raw: RawContract = serde_wasm_bindgen::from_value(source).map_err(wasm_err)?;
-        Ok(contracts_to_array(Contract::build(&raw)))
+        Ok(contracts_to_array(Contract::build(raw)))
     }
 
     /// Returns `true` when two contracts have the same deterministic


### PR DESCRIPTION
Variant expansion converted the `RawContract` to JSON before expanding variants and merging sub-properties. That implementation was a necessity of the migration to Rust, where there was still a circular  dependency between types. With the migration finished, this can now use the local library types, avoiding the need for the conversion.

`Contract::build` and `variants::build` now consume the input reducing the number of clones.

 This PR also improves `Contract::interpolate`,  avoiding the need for cloning all children and improves merging of children during variant expansion

Change-type: patch